### PR TITLE
Do not display errors in debug output

### DIFF
--- a/stanford_courses.feeds_importer_default.inc
+++ b/stanford_courses.feeds_importer_default.inc
@@ -93,7 +93,7 @@ function stanford_courses_feeds_importer_default() {
         ),
         'context' => '//courses/course',
         'exp' => array(
-          'errors' => 1,
+          'errors' => 0,
           'debug' => array(
             'context' => 0,
             'xpathparser:0' => 0,


### PR DESCRIPTION
@sherakama this is the setting at `admin/structure/feeds/stanford_course_importer/settings/FeedsXPathParserXML`, "Debug Options -> Show error messages".

I don't think we want to do that.