### PR TITLE
Offset current courses section start dates by 2 weeks

### DIFF
--- a/modules/stanford_course_views/stanford_course_views.info
+++ b/modules/stanford_course_views/stanford_course_views.info
@@ -12,4 +12,3 @@ dependencies[] = views_bulk_operations
 features[ctools][] = views:views_default:3.0
 features[features_api][] = api:2
 features[views_view][] = courses
-mtime = 1424457152

--- a/modules/stanford_course_views/stanford_course_views.views_default.inc
+++ b/modules/stanford_course_views/stanford_course_views.views_default.inc
@@ -445,7 +445,7 @@ function stanford_course_views_views_default_views() {
   $handler->display->display_options['filters']['field_s_course_section_dates_value2']['relationship'] = 'field_s_course_section_info_value';
   $handler->display->display_options['filters']['field_s_course_section_dates_value2']['operator'] = '>=';
   $handler->display->display_options['filters']['field_s_course_section_dates_value2']['group'] = 1;
-  $handler->display->display_options['filters']['field_s_course_section_dates_value2']['default_date'] = 'now';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value2']['default_date'] = 'now +2 weeks';
   $handler->display->display_options['path'] = 'courses';
 
   /* Display: Search Page */

--- a/modules/stanford_course_views/stanford_course_views.views_default.inc
+++ b/modules/stanford_course_views/stanford_course_views.views_default.inc
@@ -399,6 +399,53 @@ function stanford_course_views_views_default_views() {
   $handler = $view->new_display('page', 'Current Page', 'current_courses_page');
   $handler->display->display_options['defaults']['title'] = FALSE;
   $handler->display->display_options['title'] = 'Current Courses';
+  $handler->display->display_options['defaults']['filter_groups'] = FALSE;
+  $handler->display->display_options['defaults']['filters'] = FALSE;
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = 1;
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'stanford_course' => 'stanford_course',
+  );
+  $handler->display->display_options['filters']['type']['group'] = 1;
+  /* Filter criterion: Field collection item: Component (field_s_course_component) */
+  $handler->display->display_options['filters']['field_s_course_component_value']['id'] = 'field_s_course_component_value';
+  $handler->display->display_options['filters']['field_s_course_component_value']['table'] = 'field_data_field_s_course_component';
+  $handler->display->display_options['filters']['field_s_course_component_value']['field'] = 'field_s_course_component_value';
+  $handler->display->display_options['filters']['field_s_course_component_value']['relationship'] = 'field_s_course_section_info_value';
+  $handler->display->display_options['filters']['field_s_course_component_value']['operator'] = 'not';
+  $handler->display->display_options['filters']['field_s_course_component_value']['value'] = array(
+    'DIS' => 'DIS',
+    'INS' => 'INS',
+    'PRC' => 'PRC',
+    'T/D' => 'T/D',
+  );
+  $handler->display->display_options['filters']['field_s_course_component_value']['group'] = 1;
+  $handler->display->display_options['filters']['field_s_course_component_value']['reduce_duplicates'] = TRUE;
+  /* Filter criterion: Field collection item: Date Range -  start date (field_s_course_section_dates) */
+  $handler->display->display_options['filters']['field_s_course_section_dates_value']['id'] = 'field_s_course_section_dates_value';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value']['table'] = 'field_data_field_s_course_section_dates';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value']['field'] = 'field_s_course_section_dates_value';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value']['relationship'] = 'field_s_course_section_info_value';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value']['operator'] = '<=';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value']['group'] = 1;
+  $handler->display->display_options['filters']['field_s_course_section_dates_value']['default_date'] = 'now +2 weeks';
+  /* Filter criterion: Field collection item: Date Range - end date (field_s_course_section_dates:value2) */
+  $handler->display->display_options['filters']['field_s_course_section_dates_value2']['id'] = 'field_s_course_section_dates_value2';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value2']['table'] = 'field_data_field_s_course_section_dates';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value2']['field'] = 'field_s_course_section_dates_value2';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value2']['relationship'] = 'field_s_course_section_info_value';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value2']['operator'] = '>=';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value2']['group'] = 1;
+  $handler->display->display_options['filters']['field_s_course_section_dates_value2']['default_date'] = 'now';
   $handler->display->display_options['path'] = 'courses';
 
   /* Display: Search Page */

--- a/modules/stanford_courses_person_reference/stanford_courses_person_reference.info
+++ b/modules/stanford_courses_person_reference/stanford_courses_person_reference.info
@@ -1,5 +1,5 @@
 name = Stanford Courses Person Reference
-description = Stanford Courses person entity reference field and views
+description = Stanford Courses person entity reference field
 core = 7.x
 package = Stanford
 version = 7.x-3.7

--- a/modules/stanford_courses_person_reference_views/stanford_courses_person_reference_views.views_default.inc
+++ b/modules/stanford_courses_person_reference_views/stanford_courses_person_reference_views.views_default.inc
@@ -408,6 +408,49 @@ function stanford_courses_person_reference_views_views_default_views() {
   $handler = $view->new_display('page', 'Current Page', 'current_courses_page');
   $handler->display->display_options['defaults']['title'] = FALSE;
   $handler->display->display_options['title'] = 'Current Courses';
+  $handler->display->display_options['defaults']['filter_groups'] = FALSE;
+  $handler->display->display_options['defaults']['filters'] = FALSE;
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = 1;
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'stanford_course' => 'stanford_course',
+  );
+  /* Filter criterion: Field collection item: Component (field_s_course_component) */
+  $handler->display->display_options['filters']['field_s_course_component_value']['id'] = 'field_s_course_component_value';
+  $handler->display->display_options['filters']['field_s_course_component_value']['table'] = 'field_data_field_s_course_component';
+  $handler->display->display_options['filters']['field_s_course_component_value']['field'] = 'field_s_course_component_value';
+  $handler->display->display_options['filters']['field_s_course_component_value']['relationship'] = 'field_s_course_section_info_value';
+  $handler->display->display_options['filters']['field_s_course_component_value']['operator'] = 'not';
+  $handler->display->display_options['filters']['field_s_course_component_value']['value'] = array(
+    'DIS' => 'DIS',
+    'INS' => 'INS',
+    'PRC' => 'PRC',
+    'T/D' => 'T/D',
+  );
+  $handler->display->display_options['filters']['field_s_course_component_value']['reduce_duplicates'] = TRUE;
+  /* Filter criterion: Field collection item: Date Range -  start date (field_s_course_section_dates) */
+  $handler->display->display_options['filters']['field_s_course_section_dates_value']['id'] = 'field_s_course_section_dates_value';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value']['table'] = 'field_data_field_s_course_section_dates';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value']['field'] = 'field_s_course_section_dates_value';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value']['relationship'] = 'field_s_course_section_info_value';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value']['operator'] = '<=';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value']['default_date'] = 'now +2 weeks';
+  /* Filter criterion: Field collection item: Date Range - end date (field_s_course_section_dates:value2) */
+  $handler->display->display_options['filters']['field_s_course_section_dates_value2']['id'] = 'field_s_course_section_dates_value2';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value2']['table'] = 'field_data_field_s_course_section_dates';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value2']['field'] = 'field_s_course_section_dates_value2';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value2']['relationship'] = 'field_s_course_section_info_value';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value2']['operator'] = '>=';
+  $handler->display->display_options['filters']['field_s_course_section_dates_value2']['default_date'] = 'now';
   $handler->display->display_options['path'] = 'courses';
 
   /* Display: Search Page */


### PR DESCRIPTION
Steps to test:

1. Install a JSA site using the `7.x-3.x-dev` branch of `stanford_courses`
1. Create a course node that has a section with the start date two weeks from now (e.g., November 16th if today is November 2nd)
1. Create a course node that has a section with the end date two weeks from now (e.g., November 16th if today is November 2nd)
1. Clear caches
1. Go to /courses
1. See no courses (this is because end date = now +2 weeks is already in the `stanford_courses_person_reference_views` View)
1. Disable `stanford_courses_person_reference_views`
1. Enable `stanford_course_views`
1. Clear caches
1. Go to /courses
1. See only the course node you created in step 3
1. Check out the `BASIC-1486-date-offset` branch of `stanford_courses`
1. Clear caches
1. Go to /courses
1. See only the test course node that you created in step 2
1. Disable `stanford_course_views`
1. Enable `stanford_courses_person_reference_views`
1. Clear caches
1. Go to /courses
1. See only the test course node that you created in step 2
1. There is no step 21
