### PR TITLE
Fixed an issue where a single tag on an event caused a translate issue

### DIFF
--- a/modules/stanford_courses_tag_translate/plugins/stanford_courses_tag_translate_tamper.inc
+++ b/modules/stanford_courses_tag_translate/plugins/stanford_courses_tag_translate_tamper.inc
@@ -58,12 +58,21 @@ function stanford_courses_tag_translate_tamper_callback($source, $item_key, $ele
       return;
     }
 
-    $index_key = array_search($field, $source->items[$item_key][$element_key]);
-    if (!is_null($index_key) && isset($source->items[$item_key][$element_key][$index_key])) {
-      unset($source->items[$item_key][$element_key][$index_key]);
+    // If the result is an array we need to find out what index of that array
+    // it is in so we can unset it. This tamper plugin gets an array when there
+    // more than one value and a single string when there is only one.
+    if (is_array($source->items[$item_key][$element_key])) {
+      $index_key = array_search($field, $source->items[$item_key][$element_key]);
+      if (!is_null($index_key) && isset($source->items[$item_key][$element_key][$index_key])) {
+        unset($source->items[$item_key][$element_key][$index_key]);
+      }
     }
-    $field = FALSE;
+    else {
+      // We have a single value and it is a string.
+      unset($source->items[$item_key][$element_key]);
+    }
 
+    $field = FALSE;
     return;
   }
 

--- a/modules/stanford_courses_tag_translate/stanford_courses_tag_translate.pages.inc
+++ b/modules/stanford_courses_tag_translate/stanford_courses_tag_translate.pages.inc
@@ -237,6 +237,11 @@ function stanford_courses_tag_translate_fields_form_validate(&$form, &$form_stat
 function stanford_courses_tag_translate_fields_form_submit(&$form, &$form_state) {
   $values = $form_state["values"];
 
+  // Protection against php notices.
+  if (!isset($values['ctid'])) {
+    $values['ctid'] = '';
+  }
+
   // The insert array for drupal_write_record.
   $insert = array(
     "ctag" => strtoupper(filter_xss($values["ctag"])),


### PR DESCRIPTION
Adds a check for an array in the results as the XMLParser will return a single string instead of an array when the xpath matches only one element. 