### PR TITLE
HSDO-957 Added and configured views_selective_filters module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ env:
     - BEHAT_TAG=""
     - DEPLOYER_BRANCH=""
     - DRUPAL_PROFILE_BRANCH=""
-    - CLICKY_BRANCH=""
+    - CLICKY_BRANCH="HSDO-957-views-selective-filters"
     - SCRIPTS_BRANCH=""
 
 language: php

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,12 +63,12 @@
 
 env:
   global:
-    - PRODUCT_NAME=""
+    - PRODUCT_NAME="jumpstart-academic"
     - ENABLE_MODULES="stanford_courses stanford_course_views stanford_courses_administration stanford_courses_link_to_page stanford_courses_matrix stanford_courses_node_display stanford_courses_person_reference stanford_courses_person_reference_views stanford_courses_tag_translate"
     - DISABLE_MODULES="webauth"
     - ONLY_TEST=""
     - BEHAT_TAG=""
-    - DEPLOYER_BRANCH=""
+    - DEPLOYER_BRANCH="jsa-labs-updates"
     - DRUPAL_PROFILE_BRANCH=""
     - CLICKY_BRANCH="HSDO-957-views-selective-filters"
     - SCRIPTS_BRANCH=""

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,9 @@
 Stanford Courses x.x-x.x, xxxx-xx-xx
 ------------------------------------
+7.x-4.x                   2017-07-20
+------------------------------------
+- New Dependency for stanford_news_views & stanford_courses_person_reference_views: views_selective_filters (views_filters_selective)
+
 7.x-4.2                   2017-07-18
 ------------------------------------
 - Behat Tests written

--- a/modules/stanford_course_views/stanford_course_views.info
+++ b/modules/stanford_course_views/stanford_course_views.info
@@ -9,6 +9,7 @@ dependencies[] = stanford_courses
 dependencies[] = stanford_image
 dependencies[] = views
 dependencies[] = views_bulk_operations
+dependencies[] = views_filters_selective
 features[ctools][] = views:views_default:3.0
 features[features_api][] = api:2
 features[views_view][] = courses

--- a/modules/stanford_course_views/stanford_course_views.install
+++ b/modules/stanford_course_views/stanford_course_views.install
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * stanford_course_views_views.install
+ */
+
+/**
+ * Enables given module or throws error.
+ *
+ * @param string $module
+ *   Machine name of module to enable.
+ *
+ * @return bool
+ *   If the module was enabled successfully.
+ */
+function stanford_course_views_enable_module($module) {
+  if (!module_exists($module)) {
+    if (!module_enable(array($module))) {
+      watchdog('stanford_course_views', 'Could not enable %module module', array('%module' => $module));
+      return FALSE;
+    }
+    else {
+      watchdog('stanford_course_views', 'Enabled stanford_field_formatters module.', array('%module' => $module));
+    }
+  }
+  return TRUE;
+}
+
+
+function stanford_course_views_update_7040() {
+  if (!stanford_course_views_enable_module('views_filters_selective')) {
+    throw new DrupalUpdateException("Could not enable views_filters_selective module. Please check that the module exists.");
+  }
+}

--- a/modules/stanford_course_views/stanford_course_views.install
+++ b/modules/stanford_course_views/stanford_course_views.install
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * stanford_course_views_views.install
+ * Stanford_course_views_views.install.
  */
 
 /**
@@ -27,7 +27,9 @@ function stanford_course_views_enable_module($module) {
   return TRUE;
 }
 
-
+/**
+ * Enables views_filters_selective module.
+ */
 function stanford_course_views_update_7040() {
   if (!stanford_course_views_enable_module('views_filters_selective')) {
     throw new DrupalUpdateException("Could not enable views_filters_selective module. Please check that the module exists.");

--- a/modules/stanford_course_views/stanford_course_views.views_default.inc
+++ b/modules/stanford_course_views/stanford_course_views.views_default.inc
@@ -558,33 +558,27 @@ function stanford_course_views_views_default_views() {
     7 => 0,
     8 => 0,
   );
-  /* Filter criterion: Field collection item: Year (field_s_course_section_year) */
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['id'] = 'field_s_course_section_year_value';
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['table'] = 'field_data_field_s_course_section_year';
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['field'] = 'field_s_course_section_year_value';
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['relationship'] = 'field_s_course_section_info_value';
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['value'] = array(
-    2013 => '2013',
-    2014 => '2014',
-  );
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['group'] = 1;
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['exposed'] = TRUE;
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['expose']['operator_id'] = 'field_s_course_section_year_value_op';
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['expose']['label'] = 'Academic year';
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['expose']['operator'] = 'field_s_course_section_year_value_op';
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['expose']['identifier'] = 'field_s_course_section_year_value';
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['expose']['remember_roles'] = array(
+  /* Filter criterion: Year (field_s_course_section_year) (selective) */
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['id'] = 'field_s_course_section_year_value_selective';
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['table'] = 'field_data_field_s_course_section_year';
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['field'] = 'field_s_course_section_year_value_selective';
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['relationship'] = 'field_s_course_section_info_value';
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['ui_name'] = 'Year (field_s_course_section_year) (selective)';
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['group'] = 1;
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['expose']['operator_id'] = '';
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['expose']['label'] = 'Academic year';
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['expose']['identifier'] = 'field_s_course_section_year_value_selective';
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,
     6 => 0,
-    5 => 0,
-    4 => 0,
     3 => 0,
-    9 => 0,
-    7 => 0,
-    8 => 0,
+    4 => 0,
+    5 => 0,
   );
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['expose']['reduce'] = TRUE;
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['selective_display_field'] = 'field_s_course_section_year';
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['selective_items_limit'] = '20';
   /* Filter criterion: Field collection item: Quarter (field_s_course_term) */
   $handler->display->display_options['filters']['field_s_course_term_value']['id'] = 'field_s_course_term_value';
   $handler->display->display_options['filters']['field_s_course_term_value']['table'] = 'field_data_field_s_course_term';

--- a/modules/stanford_courses_person_reference_views/stanford_courses_person_reference_views.info
+++ b/modules/stanford_courses_person_reference_views/stanford_courses_person_reference_views.info
@@ -7,6 +7,7 @@ project = stanford_courses_person_reference_views
 dependencies[] = ctools
 dependencies[] = stanford_courses_person_reference
 dependencies[] = views
+dependencies[] = views_filters_selective
 features[ctools][] = views:views_default:3.0
 features[features_api][] = api:2
 features[views_view][] = courses_reference

--- a/modules/stanford_courses_person_reference_views/stanford_courses_person_reference_views.install
+++ b/modules/stanford_courses_person_reference_views/stanford_courses_person_reference_views.install
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * stanford_courses_person_reference_views.install
+ */
+
+/**
+ * Enables given module or throws error.
+ *
+ * @param string $module
+ *   Machine name of module to enable.
+ *
+ * @return bool
+ *   If the module was enabled successfully.
+ */
+function stanford_courses_person_reference_enable_module($module) {
+  if (!module_exists($module)) {
+    if (!module_enable(array($module))) {
+      watchdog('stanford_courses_person_reference', 'Could not enable %module module', array('%module' => $module));
+      return FALSE;
+    }
+    else {
+      watchdog('stanford_courses_person_reference', 'Enabled stanford_field_formatters module.', array('%module' => $module));
+    }
+  }
+  return TRUE;
+}
+
+
+function stanford_courses_person_reference_update_7040() {
+  if (!stanford_courses_person_reference_enable_module('views_filters_selective')) {
+    throw new DrupalUpdateException("Could not enable views_filters_selective module. Please check that the module exists.");
+  }
+}

--- a/modules/stanford_courses_person_reference_views/stanford_courses_person_reference_views.install
+++ b/modules/stanford_courses_person_reference_views/stanford_courses_person_reference_views.install
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Stanford_courses_person_reference_views.install
+ * Stanford_courses_person_reference_views.install.
  */
 
 /**

--- a/modules/stanford_courses_person_reference_views/stanford_courses_person_reference_views.install
+++ b/modules/stanford_courses_person_reference_views/stanford_courses_person_reference_views.install
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * stanford_courses_person_reference_views.install
+ * Stanford_courses_person_reference_views.install
  */
 
 /**
@@ -27,7 +27,9 @@ function stanford_courses_person_reference_enable_module($module) {
   return TRUE;
 }
 
-
+/**
+ * Enables views_filters_selective module.
+ */
 function stanford_courses_person_reference_update_7040() {
   if (!stanford_courses_person_reference_enable_module('views_filters_selective')) {
     throw new DrupalUpdateException("Could not enable views_filters_selective module. Please check that the module exists.");

--- a/modules/stanford_courses_person_reference_views/stanford_courses_person_reference_views.views_default.inc
+++ b/modules/stanford_courses_person_reference_views/stanford_courses_person_reference_views.views_default.inc
@@ -498,6 +498,7 @@ function stanford_courses_person_reference_views_views_default_views() {
   $handler->display->display_options['filters']['type']['value'] = array(
     'stanford_course' => 'stanford_course',
   );
+  $handler->display->display_options['filters']['type']['group'] = 1;
   /* Filter criterion: Field collection item: Component (field_s_course_component) */
   $handler->display->display_options['filters']['field_s_course_component_value']['id'] = 'field_s_course_component_value';
   $handler->display->display_options['filters']['field_s_course_component_value']['table'] = 'field_data_field_s_course_component';
@@ -510,12 +511,14 @@ function stanford_courses_person_reference_views_views_default_views() {
     'PRC' => 'PRC',
     'T/D' => 'T/D',
   );
+  $handler->display->display_options['filters']['field_s_course_component_value']['group'] = 1;
   $handler->display->display_options['filters']['field_s_course_component_value']['reduce_duplicates'] = TRUE;
   /* Filter criterion: Global: Combine fields filter */
   $handler->display->display_options['filters']['combine']['id'] = 'combine';
   $handler->display->display_options['filters']['combine']['table'] = 'views';
   $handler->display->display_options['filters']['combine']['field'] = 'combine';
   $handler->display->display_options['filters']['combine']['operator'] = 'word';
+  $handler->display->display_options['filters']['combine']['group'] = 1;
   $handler->display->display_options['filters']['combine']['exposed'] = TRUE;
   $handler->display->display_options['filters']['combine']['expose']['operator_id'] = 'combine_op';
   $handler->display->display_options['filters']['combine']['expose']['label'] = 'Search all courses by keyword';
@@ -537,37 +540,33 @@ function stanford_courses_person_reference_views_views_default_views() {
     'field_s_course_code_2' => 'field_s_course_code_2',
     'title' => 'title',
   );
-  /* Filter criterion: Field collection item: Year (field_s_course_section_year) */
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['id'] = 'field_s_course_section_year_value';
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['table'] = 'field_data_field_s_course_section_year';
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['field'] = 'field_s_course_section_year_value';
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['relationship'] = 'field_s_course_section_info_value';
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['value'] = array(
-    2013 => '2013',
-    2014 => '2014',
-  );
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['exposed'] = TRUE;
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['expose']['operator_id'] = 'field_s_course_section_year_value_op';
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['expose']['label'] = 'Academic year';
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['expose']['operator'] = 'field_s_course_section_year_value_op';
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['expose']['identifier'] = 'field_s_course_section_year_value';
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['expose']['remember_roles'] = array(
+  /* Filter criterion: Year (field_s_course_section_year) (selective) */
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['id'] = 'field_s_course_section_year_value_selective';
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['table'] = 'field_data_field_s_course_section_year';
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['field'] = 'field_s_course_section_year_value_selective';
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['relationship'] = 'field_s_course_section_info_value';
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['ui_name'] = 'Year (field_s_course_section_year) (selective)';
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['group'] = 1;
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['expose']['operator_id'] = '';
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['expose']['label'] = 'Academic year';
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['expose']['identifier'] = 'field_s_course_section_year_value_selective';
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,
     6 => 0,
-    5 => 0,
-    4 => 0,
     3 => 0,
-    9 => 0,
-    7 => 0,
-    8 => 0,
+    4 => 0,
+    5 => 0,
   );
-  $handler->display->display_options['filters']['field_s_course_section_year_value']['expose']['reduce'] = TRUE;
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['selective_display_field'] = 'field_s_course_section_year';
+  $handler->display->display_options['filters']['field_s_course_section_year_value_selective']['selective_items_limit'] = '20';
   /* Filter criterion: Field collection item: Quarter (field_s_course_term) */
   $handler->display->display_options['filters']['field_s_course_term_value']['id'] = 'field_s_course_term_value';
   $handler->display->display_options['filters']['field_s_course_term_value']['table'] = 'field_data_field_s_course_term';
   $handler->display->display_options['filters']['field_s_course_term_value']['field'] = 'field_s_course_term_value';
   $handler->display->display_options['filters']['field_s_course_term_value']['relationship'] = 'field_s_course_section_info_value';
+  $handler->display->display_options['filters']['field_s_course_term_value']['group'] = 1;
   $handler->display->display_options['filters']['field_s_course_term_value']['exposed'] = TRUE;
   $handler->display->display_options['filters']['field_s_course_term_value']['expose']['operator_id'] = 'field_s_course_term_value_op';
   $handler->display->display_options['filters']['field_s_course_term_value']['expose']['label'] = 'Quarter';


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- NEW DEPENDENCY: https://www.drupal.org/project/views_selective_filters
- switch basic filter for selective filter on course search page.

# Needed By (Date)
- ASAP

# Urgency
- High: time sensitive with the switch of academic year coming.

# Steps to Test

1. checkout branch & `drush dl views_selective_filters -y; drush en views_filters_selective -y` (hate that the repo name is different than the module files)
2. `drush fr stanford_course_views stanford_courses_person_reference_views -y`
3. view /courses/all page
4. view options in the "Academic Year" select
5. create a new courese with a different academic year for section
6. verify that academic year you chose now displays in the select list on courses/all

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)