### PR TITLE
SITES-530: prevent fatal error on database update

### DIFF
--- a/stanford_courses.install
+++ b/stanford_courses.install
@@ -541,7 +541,8 @@ function stanford_courses_update_7404(&$sandbox) {
         );
         try {
           $field_collection->save();
-        } catch (Exception $e) {
+        }
+        catch (Exception $e) {
           watchdog('stanford_courses', 'Unable to save field collection !id', array('id' => $item_id));
         }
       }

--- a/stanford_courses.install
+++ b/stanford_courses.install
@@ -526,30 +526,32 @@ function stanford_courses_update_7404(&$sandbox) {
     $sandbox['total'] = count($sandbox['ids']);
   }
 
-  // Chunk the nodes into 10 per execution.
+  // Chunk the nodes into 50 per execution.
   $chunks = array_chunk($sandbox['ids'], 50, TRUE);
-
-  foreach (field_collection_item_load_multiple(array_keys($chunks[0])) as $item_id => $field_collection) {
-    /** @var FieldCollectionViewMode $field_collection */
-    $year = field_get_items('field_collection_item', $field_collection, 'field_s_course_section_year');
-    if ($year) {
-      $field_collection->field_s_course_year_computed[LANGUAGE_NONE][0] = array(
-        'value' => ($year[0]['value'] + 1) . "-01-01 00:00:00",
-        'timezone' => 'America/Los_Angeles',
-        'timezone_db' => 'America/Los_Angeles',
-        'date_type' => 'datetime',
-      );
-      try {
-        $field_collection->save();
-      }
-      catch (Exception $e) {
-        watchdog('stanford_courses', 'Unable to save field collection !id', array('id' => $item_id));
+  if (is_array($chunks[0])) {
+    foreach (field_collection_item_load_multiple(array_keys($chunks[0])) as $item_id => $field_collection) {
+      /** @var FieldCollectionViewMode $field_collection */
+      $year = field_get_items('field_collection_item', $field_collection, 'field_s_course_section_year');
+      if ($year) {
+        $field_collection->field_s_course_year_computed[LANGUAGE_NONE][0] = array(
+          'value' => ($year[0]['value'] + 1) . "-01-01 00:00:00",
+          'timezone' => 'America/Los_Angeles',
+          'timezone_db' => 'America/Los_Angeles',
+          'date_type' => 'datetime',
+        );
+        try {
+          $field_collection->save();
+        } catch (Exception $e) {
+          watchdog('stanford_courses', 'Unable to save field collection !id', array('id' => $item_id));
+        }
       }
     }
-  }
 
-  foreach (array_keys($chunks[0]) as $item_id) {
-    unset($sandbox['ids'][$item_id]);
+
+    foreach (array_keys($chunks[0]) as $item_id) {
+      unset($sandbox['ids'][$item_id]);
+    }
+
+    $sandbox['#finished'] = 1 - (count($sandbox['ids']) / $sandbox['total']);
   }
-  $sandbox['#finished'] = 1 - (count($sandbox['ids']) / $sandbox['total']);
 }

--- a/stanford_courses.install
+++ b/stanford_courses.install
@@ -548,11 +548,10 @@ function stanford_courses_update_7404(&$sandbox) {
       }
     }
 
-
     foreach (array_keys($chunks[0]) as $item_id) {
       unset($sandbox['ids'][$item_id]);
     }
-
-    $sandbox['#finished'] = 1 - (count($sandbox['ids']) / $sandbox['total']);
   }
+
+  $sandbox['#finished'] = 1 - (count($sandbox['ids']) / $sandbox['total']);
 }


### PR DESCRIPTION
See https://stanfordits.atlassian.net/browse/SITES-530

This is a band-aid; I'm just posting this for discussion. I'm not entirely sure why the array is not getting populated correctly.

To test:

1. `drush @acsf.dev.cardinald7.eao sql-dump > eao.sql`
2. `lando db-import eao.sql`
3. `lando drush updb`
4. See many errors
5. Check out this branch of `stanford_courses`
6. `lando drush updb`
7. See no errors