### PR TITLE
Avoid dividing by 0

### DIFF
--- a/stanford_courses.install
+++ b/stanford_courses.install
@@ -552,7 +552,8 @@ function stanford_courses_update_7404(&$sandbox) {
     foreach (array_keys($chunks[0]) as $item_id) {
       unset($sandbox['ids'][$item_id]);
     }
-
-    $sandbox['#finished'] = 1 - (count($sandbox['ids']) / $sandbox['total']);
+    if (is_numeric($sandbox['total'])) {
+      $sandbox['#finished'] = 1 - (count($sandbox['ids']) / $sandbox['total']);
+    }
   }
 }

--- a/stanford_courses.install
+++ b/stanford_courses.install
@@ -555,6 +555,4 @@ function stanford_courses_update_7404(&$sandbox) {
       $sandbox['#finished'] = 1 - (count($sandbox['ids']) / $sandbox['total']);
     }
   }
-
-  $sandbox['#finished'] = 1 - (count($sandbox['ids']) / $sandbox['total']);
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- TL;DR - what's this PR for? It moves the `$sandbox` calculation back inside the check whether `$chunks[0']` is an array. It also checks that `$sandbox['total']` is numeric. Either one of those moves is probably sufficient to avoid `Division by zero stanford_courses.install:556 `

# Needed By (Date)
- When does this need to be merged by? Socorro go-live

# Criticality
- How critical is this PR on a 1-10 scale? 2
- E.g., it affects one site, or every site and product?

# Steps to Test

1. Check out this branch
2. `drush @acsf.cardinald7.eao sql-dump > eao.sql`
3. `lando db-import eao.sql`
4. `lando drush -y updb`
5. See no errors

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules? Socorro

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-530

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)