### PR TITLE
Add component allowed values

### DIFF
--- a/stanford_courses.features.field_base.inc
+++ b/stanford_courses.features.field_base.inc
@@ -84,6 +84,8 @@ function stanford_courses_field_default_field_bases() {
     'settings' => array(
       'allowed_values' => array(
         'ACT' => 'ACT',
+        'API' => 'API',
+        'CAS' => 'CAS',
         'CLK' => 'CLK',
         'COL' => 'COL',
         'DIS' => 'DIS',
@@ -94,6 +96,7 @@ function stanford_courses_field_default_field_bases() {
         'LBS' => 'LBS',
         'LAB' => 'LAB',
         'LEC' => 'LEC',
+        'PRA' => 'PRA',
         'PRC' => 'PRC',
         'LNG' => 'LNG',
         'IDS' => 'IDS',


### PR DESCRIPTION
@jbickar and @sherakama, these are new component allowed values that may not have been present when last the allowed_values array was modified in 2014 with https://github.com/SU-SWS/stanford_courses/commit/f2d3e3d0e635985ac7e353889887d85e602b25c7 .

Also attaching a screenshot of the current ExploreCourses component filters.

![component_filters_2019](https://user-images.githubusercontent.com/1510449/52881199-d724cc80-3118-11e9-97e3-bfc4868814e1.png)

It would be nice to use Practicum (PRA) and Case Study (CAS) .
